### PR TITLE
Update concepts-networking-ssl-tls.md

### DIFF
--- a/articles/postgresql/flexible-server/concepts-networking-ssl-tls.md
+++ b/articles/postgresql/flexible-server/concepts-networking-ssl-tls.md
@@ -128,7 +128,7 @@ Microsoft RSA Root Certificate Authority 2017  https://www.microsoft.com/pkiops/
 To import certificates to client certificate stores you may have to **convert certificate .crt files to .pem format**, after downloading certificate files from URIs above. You can use OpenSSL utility to do these file conversions, as shown in example below:
 
 ```powershell
-openssl x509 -in certificate.crt -out certificate.pem -outform PEM
+openssl x509 -inform DER -in certificate.crt -out certificate.pem -outform PEM
 ```
 
 **Detailed information on updating client applications certificate stores with new Root CA certificates has been documented in this [how-to document](../flexible-server/how-to-update-client-certificates-java.md)**. 


### PR DESCRIPTION
We found that current "Microsoft RSA Root Certificate Authority 2017" is certificate file, so we would need to add extra "-inform DER" during converting certificate file to PEM file.

* The DER format is the DER encoding of the certificate and PEM is the base64 encoding of the DER encoding with header and footer lines added. The default format is PEM.